### PR TITLE
Fix for Dn Famitracker text export

### DIFF
--- a/text2data/text2vol5.cpp
+++ b/text2data/text2vol5.cpp
@@ -519,6 +519,8 @@ void parse_instruments(void)
 	//parse envelopes
 
 	off = text_find_tag("# Macros", 0);
+	// Dn Famitracker changed the comment line format. Try again.
+	if(off == -1) off = text_find_tag("# SEQUENCES", 0);
 
 	if (off < 0) parse_error(off, "Macros section not found");
 
@@ -587,6 +589,8 @@ void parse_instruments(void)
 	for (i = 0; i < MAX_INSTRUMENTS; ++i) sample_list[i].id = -1;
 
 	off = text_find_tag("# Instruments", off);
+	// Dn Famitracker changed the comment line format. Try again.
+	if(off == -1) off = text_find_tag("# INSTRUMENTS", 0);
 
 	if (off < 0) parse_error(off, "Instruments section not found");
 


### PR DESCRIPTION
`text2vol` uses the comment lines in the text export as section headers. Dn Famitracker changed these comment lines. Just need to add a second lookup for them.